### PR TITLE
Added module to arche label in parens

### DIFF
--- a/cyclist/src/edu/utexas/cycic/Cycic.java
+++ b/cyclist/src/edu/utexas/cycic/Cycic.java
@@ -540,7 +540,7 @@ public class Cycic extends ViewBase{
 		circle.setFill(Color.rgb(circle.rgbColor.get(0),circle.rgbColor.get(1),circle.rgbColor.get(2)));
 		circle.setCenterX(45+(i*90));
 		circle.setCenterY(50);
-		circle.text.setText(name.split(" ")[2]);
+		circle.text.setText(name.split(" ")[2] + " (" + name.split(" ")[1] + ")");
 		circle.text.setWrapText(true);
 		circle.text.setMaxWidth(60);
 		circle.text.setLayoutX(circle.getCenterX()-circle.getRadius()*0.7);


### PR DESCRIPTION
Fixes #25 

I chose to add the module name (is this the right term?) in parens after the archetype name.