### PR TITLE
remove quotes from string values

### DIFF
--- a/cyclist/src/edu/utexas/cycic/OutPut.java
+++ b/cyclist/src/edu/utexas/cycic/OutPut.java
@@ -389,7 +389,8 @@ public class OutPut {
 					break;
 				}
 				Element name = doc.createElement((String) facArray.get(0).toString().replace(" ", "").replace("\"", ""));
-				name.appendChild(doc.createTextNode((String)dataArray.get(0)));
+                                String s = (String)dataArray.get(0);
+				name.appendChild(doc.createTextNode(s.replace("\"", "")));
 				rootElement.appendChild(name);
 			}
 		}


### PR DESCRIPTION
Previously, Cycic would inject quotes into string variables which cannot be read properly. This removes all such quotes in facility forms.

@FlanFlanagan, do you think you can review this, merge it, and get a new windows binary up for users to download?